### PR TITLE
allow arrow functions for react component definition

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -1,5 +1,6 @@
 module.exports = {
   extends: 'airbnb',
+  'react/function-component-definition': 'arrow-function',
   settings: {
     react: {
       version: '17',


### PR DESCRIPTION
modified this rule: 
https://github.com/jsx-eslint/eslint-plugin-react/blob/master/docs/rules/function-component-definition.md