### PR TITLE
[M] Refactor to use central Redux Store (#128)

### DIFF
--- a/client/src/App.jsx
+++ b/client/src/App.jsx
@@ -1,39 +1,58 @@
 import React, { useState, useEffect } from 'react';
-import axios from 'axios';
 import ProductDetails from './components/ProductDetails';
 import RelatedItems from './components/RelatedItems';
 import QuestionsAndAnswers from './components/QuestionsAndAnswers';
 import RatingsAndReviews from './components/RatingsAndReviews';
 import NavBar from './components/NavBar';
 
+import { useDispatch, useSelector } from 'react-redux';
+import { fetchProducts } from './state/products/productsSlice';
+import { fetchProductInfo } from './state/products/productInfoSlice';
+import { fetchProductStyles } from './state/products/productStylesSlice';
+import { fetchReviewsMeta } from './state/reviews/reviewsMetaSlice';
 import './global.css';
 
+
 const App = () => {
+
+  const dispatch = useDispatch();
+  const products = useSelector(state => state.products.data);  
   const [productId, setProductId] = useState(null);
 
   useEffect(() => {
-    axios.get('/products')
-      .then(response => {
-        const firstProductId = response.data[0].id;
-        setProductId(firstProductId);
-      })
-      .catch(error => {
-        console.error('Fail:', error);
-      });
-  }, []);
+    dispatch(fetchProducts());
+  }, [dispatch]);
+
+  //setFirstProductId
+  useEffect(() => {
+    if(!productId && products?.length > 0 && products[0]?.id) {
+      setProductId(products[0].id); 
+    }
+  }, [products, productId]);
+
+  //dispatch product apis
+  useEffect(() => {
+    if (productId) {
+      dispatch(fetchProductInfo(productId));
+      dispatch(fetchProductStyles(productId));
+      dispatch(fetchReviewsMeta(productId));
+    }
+  }, [productId])
+  
+
 
   return (
-    <div>
-      <NavBar />
-      {productId && (
-        <>
-          <ProductDetails productId={productId} />
-          <RelatedItems productId={productId} setProductId={setProductId} />
-          <QuestionsAndAnswers  product_id={productId}/>
-          <RatingsAndReviews productId={productId} />
-        </>
-      )}
-    </div>
+      <div>
+        <NavBar />
+        {productId && (
+          <>
+            <ProductDetails productId={productId} />
+            <RelatedItems productId={productId} setProductId={setProductId} />
+            <QuestionsAndAnswers product_id={productId} />
+            <RatingsAndReviews productId={productId} />
+          </>
+        )}
+      </div>
   );
 };
 

--- a/client/src/components/ProductDetails/ProductGallery/Carousel.jsx
+++ b/client/src/components/ProductDetails/ProductGallery/Carousel.jsx
@@ -109,7 +109,7 @@ const Carousel = ({
       <div className='pd-carousel-transform-container'>
         {photos?.map((photo, i) => (
           <div 
-            key={photo.url} 
+            key={photo.url + i} 
             className='pd-carousel-transform-element' 
             style={{ transform: `translate(${0 - photoIndex * 100}%)`}}
           >

--- a/client/src/index.jsx
+++ b/client/src/index.jsx
@@ -1,9 +1,16 @@
-import React from 'react';
-import { render } from 'react-dom';
-import App from './App';
+import React from "react";
+import { render } from "react-dom";
+import { Provider } from 'react-redux';
+import { store } from './state/store';
+import App from "./App";
 
-const root = document.createElement('div');
-root.setAttribute('id', 'root');
+const root = document.createElement("div");
+root.setAttribute("id", "root");
 document.body.appendChild(root);
 
-render(<App />, root);
+render(
+  <Provider store={store}>
+    <App />
+  </Provider>,
+  root
+);

--- a/client/src/state/products/productInfoSlice.js
+++ b/client/src/state/products/productInfoSlice.js
@@ -1,0 +1,37 @@
+import { createSlice, createAsyncThunk } from '@reduxjs/toolkit';
+import axios from 'axios'; 
+
+const initialState = {
+  data: {}, 
+  isLoading: false, 
+  error: null,
+};
+
+export const fetchProductInfo = createAsyncThunk(
+  'productInfo/fetchProductInfo', 
+  async (productId) => {
+    const res = await axios.get(`/products/${productId}`);
+    return res.data; 
+  }
+)
+
+const productInfoSlice = createSlice({
+  name: 'productInfo', 
+  initialState, 
+  reducers: {},
+  extraReducers: (builder) => {
+    builder.addCase(fetchProductInfo.pending, (state) => {
+      state.isLoading = true
+    });
+    builder.addCase(fetchProductInfo.fulfilled, (state, action) => {
+      state.isLoading = false
+      state.data = {...state.data, [action.payload.id]: action.payload }
+    });
+    builder.addCase(fetchProductInfo.rejected, (state, action) => {
+      state.isLoading = false
+      state.error = action.error.message
+    });
+  }
+}); 
+
+export default productInfoSlice.reducer; 

--- a/client/src/state/products/productStylesSlice.js
+++ b/client/src/state/products/productStylesSlice.js
@@ -1,0 +1,37 @@
+import { createSlice, createAsyncThunk } from '@reduxjs/toolkit';
+import axios from 'axios'; 
+
+const initialState = {
+  data: {}, 
+  isLoading: false, 
+  error: null,
+};
+
+export const fetchProductStyles = createAsyncThunk(
+  'productStyles/fetchProductStyles', 
+  async (productId) => {
+    const res = await axios.get(`/products/${productId}/styles`);
+    return res.data; 
+  }
+)
+
+const productStylesSlice = createSlice({
+  name: 'productStyles', 
+  initialState, 
+  reducers: {},
+  extraReducers: (builder) => {
+    builder.addCase(fetchProductStyles.pending, (state) => {
+      state.isLoading = true
+    });
+    builder.addCase(fetchProductStyles.fulfilled, (state, action) => {
+      state.isLoading = false
+      state.data = {...state.data, [action.payload.product_id]: action.payload }
+    });
+    builder.addCase(fetchProductStyles.rejected, (state, action) => {
+      state.isLoading = false
+      state.error = action.error.message
+    });
+  }
+}); 
+
+export default productStylesSlice.reducer; 

--- a/client/src/state/products/productsSlice.js
+++ b/client/src/state/products/productsSlice.js
@@ -1,0 +1,37 @@
+import { createSlice, createAsyncThunk } from '@reduxjs/toolkit';
+import axios from 'axios'; 
+
+const initialState = {
+  data: [], 
+  isLoading: false, 
+  error: null,
+};
+
+export const fetchProducts = createAsyncThunk(
+  'products/fetchProducts', 
+  async () => {
+    const res = await axios.get('/products');
+    return res.data; 
+  }
+)
+
+const productsSlice = createSlice({
+  name: 'products', 
+  initialState, 
+  reducers: {},
+  extraReducers: (builder) => {
+    builder.addCase(fetchProducts.pending, (state) => {
+      state.isLoading = true
+    });
+    builder.addCase(fetchProducts.fulfilled, (state, action) => {
+      state.isLoading = false
+      state.data = action.payload
+    });
+    builder.addCase(fetchProducts.rejected, (state, action) => {
+      state.isLoading = false
+      state.error = action.error.message
+    });
+  }
+}); 
+
+export default productsSlice.reducer; 

--- a/client/src/state/reviews/reviewsMetaSlice.js
+++ b/client/src/state/reviews/reviewsMetaSlice.js
@@ -1,0 +1,48 @@
+import { createSlice, createAsyncThunk } from '@reduxjs/toolkit';
+import axios from 'axios'; 
+
+const initialState = {
+  data: {}, 
+  isLoading: false, 
+  error: null,
+};
+
+export const fetchReviewsMeta = createAsyncThunk(
+  'reviewsMeta/fetchReviewsMeta', 
+  async (productId) => {
+    const res = await axios.get(`/reviews/meta?product_id=${productId}`);
+    const ratings = res?.data?.ratings ?? {};
+    let count = 0;
+    let total = 0;
+    Object.entries(ratings).forEach((entry) => {
+      count += +(entry?.[1] ?? 0);
+      total += +(entry?.[0] ?? 0) * +(entry?.[1] ?? 0);
+    });
+    const ratingsSummary = {
+      count: count, 
+      average: total / count
+    }
+    return {...res.data, ratingsSummary}; 
+  }
+)
+
+const reviewsMetaSlice = createSlice({
+  name: 'reviewsMeta', 
+  initialState, 
+  reducers: {},
+  extraReducers: (builder) => {
+    builder.addCase(fetchReviewsMeta.pending, (state) => {
+      state.isLoading = true
+    });
+    builder.addCase(fetchReviewsMeta.fulfilled, (state, action) => {
+      state.isLoading = false
+      state.data = {...state.data, [action.payload.product_id]: action.payload }
+    });
+    builder.addCase(fetchReviewsMeta.rejected, (state, action) => {
+      state.isLoading = false
+      state.error = action.error.message
+    });
+  }
+}); 
+
+export default reviewsMetaSlice.reducer; 

--- a/client/src/state/store.js
+++ b/client/src/state/store.js
@@ -1,0 +1,15 @@
+import { configureStore } from '@reduxjs/toolkit'; 
+import productsReducer from './products/productsSlice'; 
+import productInfoSlice from './products/productInfoSlice';
+import productStylesSlice from './products/productStylesSlice';
+import reviewsMetaSlice from './reviews/reviewsMetaSlice';
+
+
+export const store = configureStore({
+  reducer: {
+    products: productsReducer,
+    productInfo: productInfoSlice,
+    productStyles: productStylesSlice,
+    reviewMeta: reviewsMetaSlice
+  }
+}); 

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,6 +13,7 @@
         "@emotion/styled": "^11.11.0",
         "@mui/icons-material": "^5.14.18",
         "@mui/material": "^5.14.18",
+        "@reduxjs/toolkit": "^1.9.7",
         "antd": "^5.11.5",
         "axios": "^1.6.2",
         "date-fns": "^2.30.0",
@@ -21,6 +22,7 @@
         "jest-environment-jsdom": "^29.7.0",
         "react": "^18.2.0",
         "react-dom": "^18.2.0",
+        "react-redux": "^8.1.3",
         "react-test-renderer": "^18.2.0",
         "swiper": "^11.0.5"
       },
@@ -3407,6 +3409,29 @@
         "react-dom": ">=16.9.0"
       }
     },
+    "node_modules/@reduxjs/toolkit": {
+      "version": "1.9.7",
+      "resolved": "https://registry.npmjs.org/@reduxjs/toolkit/-/toolkit-1.9.7.tgz",
+      "integrity": "sha512-t7v8ZPxhhKgOKtU+uyJT13lu4vL7az5aFi4IdoDs/eS548edn2M8Ik9h8fxgvMjGoAUVFSt6ZC1P5cWmQ014QQ==",
+      "dependencies": {
+        "immer": "^9.0.21",
+        "redux": "^4.2.1",
+        "redux-thunk": "^2.4.2",
+        "reselect": "^4.1.8"
+      },
+      "peerDependencies": {
+        "react": "^16.9.0 || ^17.0.0 || ^18",
+        "react-redux": "^7.2.1 || ^8.0.2"
+      },
+      "peerDependenciesMeta": {
+        "react": {
+          "optional": true
+        },
+        "react-redux": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/@sinclair/typebox": {
       "version": "0.27.8",
       "resolved": "https://registry.npmjs.org/@sinclair/typebox/-/typebox-0.27.8.tgz",
@@ -3721,6 +3746,15 @@
         "@types/node": "*"
       }
     },
+    "node_modules/@types/hoist-non-react-statics": {
+      "version": "3.3.5",
+      "resolved": "https://registry.npmjs.org/@types/hoist-non-react-statics/-/hoist-non-react-statics-3.3.5.tgz",
+      "integrity": "sha512-SbcrWzkKBw2cdwRTwQAswfpB9g9LJWfjtUeW/jvNwbhC8cpmmNYVePa+ncbUe0rGTQ7G3Ff6mYUN2VMfLVr+Sg==",
+      "dependencies": {
+        "@types/react": "*",
+        "hoist-non-react-statics": "^3.3.0"
+      }
+    },
     "node_modules/@types/html-minifier-terser": {
       "version": "6.1.0",
       "resolved": "https://registry.npmjs.org/@types/html-minifier-terser/-/html-minifier-terser-6.1.0.tgz",
@@ -3844,7 +3878,7 @@
       "version": "18.2.15",
       "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-18.2.15.tgz",
       "integrity": "sha512-HWMdW+7r7MR5+PZqJF6YFNSCtjz1T0dsvo/f1BV6HkV+6erD/nA7wd9NM00KVG83zf2nJ7uATPO9ttdIPvi3gg==",
-      "dev": true,
+      "devOptional": true,
       "dependencies": {
         "@types/react": "*"
       }
@@ -3923,6 +3957,11 @@
       "version": "4.0.5",
       "resolved": "https://registry.npmjs.org/@types/tough-cookie/-/tough-cookie-4.0.5.tgz",
       "integrity": "sha512-/Ad8+nIOV7Rl++6f1BdKxFSMgmoqEoYbHRpPcx3JEfv8VRsQe9Z4mCXeJBzxs7mbHY/XOZZuXlRNfhpVPbs6ZA=="
+    },
+    "node_modules/@types/use-sync-external-store": {
+      "version": "0.0.3",
+      "resolved": "https://registry.npmjs.org/@types/use-sync-external-store/-/use-sync-external-store-0.0.3.tgz",
+      "integrity": "sha512-EwmlvuaxPNej9+T4v5AuBPJa2x2UOJVdjCtDHgcDqitUeOtjnJKJ+apYjVcAoBEMjKW1VVFGZLUb5+qqa09XFA=="
     },
     "node_modules/@types/ws": {
       "version": "8.5.9",
@@ -8347,6 +8386,15 @@
       "integrity": "sha512-Ius2VYcGNk7T90CppJqcIkS5ooHUZyIQK+ClZfMfMNFEF9VSE73Fq+906u/CWu92x4gzZMWOwfFYckPObzdEbA==",
       "dev": true
     },
+    "node_modules/immer": {
+      "version": "9.0.21",
+      "resolved": "https://registry.npmjs.org/immer/-/immer-9.0.21.tgz",
+      "integrity": "sha512-bc4NBHqOqSfRW7POMkHd51LvClaeMXpm8dx0e8oE2GORbq5aRK7Bxl4FyzVLdGtLmvLKL7BTDBG5ACQm4HWjTA==",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/immer"
+      }
+    },
     "node_modules/import-fresh": {
       "version": "3.3.0",
       "resolved": "https://registry.npmjs.org/import-fresh/-/import-fresh-3.3.0.tgz",
@@ -12234,6 +12282,44 @@
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-18.2.0.tgz",
       "integrity": "sha512-xWGDIW6x921xtzPkhiULtthJHoJvBbF3q26fzloPCK0hsvxtPVelvftw3zjbHWSkR2km9Z+4uxbDDK/6Zw9B8w=="
     },
+    "node_modules/react-redux": {
+      "version": "8.1.3",
+      "resolved": "https://registry.npmjs.org/react-redux/-/react-redux-8.1.3.tgz",
+      "integrity": "sha512-n0ZrutD7DaX/j9VscF+uTALI3oUPa/pO4Z3soOBIjuRn/FzVu6aehhysxZCLi6y7duMf52WNZGMl7CtuK5EnRw==",
+      "dependencies": {
+        "@babel/runtime": "^7.12.1",
+        "@types/hoist-non-react-statics": "^3.3.1",
+        "@types/use-sync-external-store": "^0.0.3",
+        "hoist-non-react-statics": "^3.3.2",
+        "react-is": "^18.0.0",
+        "use-sync-external-store": "^1.0.0"
+      },
+      "peerDependencies": {
+        "@types/react": "^16.8 || ^17.0 || ^18.0",
+        "@types/react-dom": "^16.8 || ^17.0 || ^18.0",
+        "react": "^16.8 || ^17.0 || ^18.0",
+        "react-dom": "^16.8 || ^17.0 || ^18.0",
+        "react-native": ">=0.59",
+        "redux": "^4 || ^5.0.0-beta.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        },
+        "react-dom": {
+          "optional": true
+        },
+        "react-native": {
+          "optional": true
+        },
+        "redux": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/react-refresh": {
       "version": "0.14.0",
       "resolved": "https://registry.npmjs.org/react-refresh/-/react-refresh-0.14.0.tgz",
@@ -12333,6 +12419,22 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/redux": {
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/redux/-/redux-4.2.1.tgz",
+      "integrity": "sha512-LAUYz4lc+Do8/g7aeRa8JkyDErK6ekstQaqWQrNRW//MY1TvCEpMtpTWvlQ+FPbWCx+Xixu/6SHt5N0HR+SB4w==",
+      "dependencies": {
+        "@babel/runtime": "^7.9.2"
+      }
+    },
+    "node_modules/redux-thunk": {
+      "version": "2.4.2",
+      "resolved": "https://registry.npmjs.org/redux-thunk/-/redux-thunk-2.4.2.tgz",
+      "integrity": "sha512-+P3TjtnP0k/FEjcBL5FZpoovtvrTNT/UXd4/sluaSyrURlSlhLSzEdfsTBW7WsKB6yPvgd7q/iZPICFjW4o57Q==",
+      "peerDependencies": {
+        "redux": "^4"
       }
     },
     "node_modules/reflect.getprototypeof": {
@@ -12486,6 +12588,11 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/requires-port/-/requires-port-1.0.0.tgz",
       "integrity": "sha512-KigOCHcocU3XODJxsu8i/j8T9tzT4adHiecwORRQ0ZZFcp7ahwXuRU1m+yuO90C5ZUyGeGfocHDI14M3L3yDAQ=="
+    },
+    "node_modules/reselect": {
+      "version": "4.1.8",
+      "resolved": "https://registry.npmjs.org/reselect/-/reselect-4.1.8.tgz",
+      "integrity": "sha512-ab9EmR80F/zQTMNeneUr4cv+jSwPJgIlvEmVwLerwrWVbpLlBuls9XHzIeTFy4cegU2NHBp3va0LKOzU5qFEYQ=="
     },
     "node_modules/resize-observer-polyfill": {
       "version": "1.5.1",
@@ -14023,6 +14130,14 @@
       "dependencies": {
         "querystringify": "^2.1.1",
         "requires-port": "^1.0.0"
+      }
+    },
+    "node_modules/use-sync-external-store": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/use-sync-external-store/-/use-sync-external-store-1.2.0.tgz",
+      "integrity": "sha512-eEgnFxGQ1Ife9bzYs6VLi8/4X6CObHMw9Qr9tPY43iKwsPw8xE8+EFsf/2cFZ5S3esXgpWgtSCtLNS41F+sKPA==",
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0"
       }
     },
     "node_modules/util-deprecate": {

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
     "@emotion/styled": "^11.11.0",
     "@mui/icons-material": "^5.14.18",
     "@mui/material": "^5.14.18",
+    "@reduxjs/toolkit": "^1.9.7",
     "antd": "^5.11.5",
     "axios": "^1.6.2",
     "date-fns": "^2.30.0",
@@ -25,6 +26,7 @@
     "jest-environment-jsdom": "^29.7.0",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
+    "react-redux": "^8.1.3",
     "react-test-renderer": "^18.2.0",
     "swiper": "^11.0.5"
   },


### PR DESCRIPTION
In an effort to centralize state related to the API and reduce overall API calls I've introduced a central redux store with redux toolkit. 

The store and slices of state lives in `/client/src/state`
App.jsx shows some example of how to use the dispatchers to fetch data from the API and save it to the store. 
Then the state in store can be received with selectors, as shown in App.jsx or also in my root component at `client/src/components/ProductDetails/index.jsx`.